### PR TITLE
Make ManyToOne bean annotation actually take effect

### DIFF
--- a/src/main/java/com/ajjpj/asqlmapper/javabeans/annotations/ManyToOne.java
+++ b/src/main/java/com/ajjpj/asqlmapper/javabeans/annotations/ManyToOne.java
@@ -1,5 +1,10 @@
 package com.ajjpj.asqlmapper.javabeans.annotations;
 
+import java.lang.annotation.*;
+
+@Target({ ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface ManyToOne {
     String referencedTable() default "";
     String fk() default "";


### PR DESCRIPTION
This annotation was missing runtime retention, so when annotations of methods annotated with this were were retrieved at runtime using reflection, this annotation was never found, meaning it was never really doing anything.
I aligned it with the other annotations in this package. It is now also restricted to methods.